### PR TITLE
[Refractor] Added support for prop-types

### DIFF
--- a/AutoComplete/AutoComplete.js
+++ b/AutoComplete/AutoComplete.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { TouchableHighlight, Text, TextInput, View } from 'react-native'
 import stringScore from 'string_score'
 import Styles from './Styles'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 
 class AutoComplete extends Component {
   componentDidMount () {

--- a/AutoComplete/AutoComplete.js
+++ b/AutoComplete/AutoComplete.js
@@ -118,18 +118,18 @@ class AutoComplete extends Component {
 }
 
 AutoComplete.propTypes = {
-  suggestions:PropTypes.array,
-  value:PropTypes.string,
-  minimumSimilarityScore:PropTypes.number,
-  comparationFuzziness:PropTypes.number,
-  suggestionObjectTextProperty:PropTypes.string,
-  onChangeText:PropTypes.func,
-  onSelect:PropTypes.func.isRequired,
-  suggestionsWrapperStyle:PropTypes.any,
-  suggestionStyle:PropTypes.any,
-  suggestionTextStyle:PropTypes.any,
-  style:PropTypes.any,
-  inputStyle:PropTypes.any
+  suggestions: PropTypes.array,
+  value: PropTypes.string,
+  minimumSimilarityScore: PropTypes.number,
+  comparationFuzziness: PropTypes.number,
+  suggestionObjectTextProperty: PropTypes.string,
+  onChangeText: PropTypes.func,
+  onSelect: PropTypes.func.isRequired,
+  suggestionsWrapperStyle: PropTypes.any,
+  suggestionStyle: PropTypes.any,
+  suggestionTextStyle: PropTypes.any,
+  style: PropTypes.any,
+  inputStyle: PropTypes.any
 }
 
 AutoComplete.defaultProps = {

--- a/AutoComplete/AutoComplete.js
+++ b/AutoComplete/AutoComplete.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { TouchableHighlight, Text, TextInput, View } from 'react-native'
 import stringScore from 'string_score'
 import Styles from './Styles'
+import PropTypes from 'prop-types';
 
 class AutoComplete extends Component {
   componentDidMount () {
@@ -117,18 +118,18 @@ class AutoComplete extends Component {
 }
 
 AutoComplete.propTypes = {
-  suggestions: React.PropTypes.array,
-  value: React.PropTypes.string,
-  minimumSimilarityScore: React.PropTypes.number,
-  comparationFuzziness: React.PropTypes.number,
-  suggestionObjectTextProperty: React.PropTypes.string,
-  onChangeText: React.PropTypes.func,
-  onSelect: React.PropTypes.func.isRequired,
-  suggestionsWrapperStyle: React.PropTypes.any,
-  suggestionStyle: React.PropTypes.any,
-  suggestionTextStyle: React.PropTypes.any,
-  style: React.PropTypes.any,
-  inputStyle: React.PropTypes.any
+  suggestions:PropTypes.array,
+  value:PropTypes.string,
+  minimumSimilarityScore:PropTypes.number,
+  comparationFuzziness:PropTypes.number,
+  suggestionObjectTextProperty:PropTypes.string,
+  onChangeText:PropTypes.func,
+  onSelect:PropTypes.func.isRequired,
+  suggestionsWrapperStyle:PropTypes.any,
+  suggestionStyle:PropTypes.any,
+  suggestionTextStyle:PropTypes.any,
+  style:PropTypes.any,
+  inputStyle:PropTypes.any
 }
 
 AutoComplete.defaultProps = {


### PR DESCRIPTION
Since React v15.5 React.PropTypes has been moved to another lib, Prop-types , so i just added import of it and removed : `React.`  in the main file.
Regards