### PR TITLE
Update PropTypes

### DIFF
--- a/AutoComplete/AutoComplete.js
+++ b/AutoComplete/AutoComplete.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { TouchableHighlight, Text, TextInput, View } from 'react-native'
 import stringScore from 'string_score'
 import Styles from './Styles'
+import PropTypes from 'prop-types';
 
 class AutoComplete extends Component {
   componentDidMount () {
@@ -117,20 +118,19 @@ class AutoComplete extends Component {
 }
 
 AutoComplete.propTypes = {
-  suggestions: React.PropTypes.array,
-  value: React.PropTypes.string,
-  minimumSimilarityScore: React.PropTypes.number,
-  comparationFuzziness: React.PropTypes.number,
-  suggestionObjectTextProperty: React.PropTypes.string,
-  onChangeText: React.PropTypes.func,
-  onSelect: React.PropTypes.func.isRequired,
-  suggestionsWrapperStyle: React.PropTypes.any,
-  suggestionStyle: React.PropTypes.any,
-  suggestionTextStyle: React.PropTypes.any,
-  style: React.PropTypes.any,
-  inputStyle: React.PropTypes.any
+suggestions: PropTypes.array,
+value: PropTypes.string,
+minimumSimilarityScore: PropTypes.number,
+comparationFuzziness: PropTypes.number,
+suggestionObjectTextProperty: PropTypes.string,
+onChangeText: PropTypes.func,
+onSelect: PropTypes.func.isRequired,
+suggestionsWrapperStyle: PropTypes.any,
+suggestionStyle: PropTypes.any,
+suggestionTextStyle: PropTypes.any,
+style: PropTypes.any,
+inputStyle: PropTypes.any
 }
-
 AutoComplete.defaultProps = {
   minimumSimilarityScore: 0.6,
   comparationFuzziness: 0.5


### PR DESCRIPTION
React.PropTypes is no longer valid in react 16
The AutoComplete.js needs to be updated.